### PR TITLE
Remove return statement, so that run_harness is executed

### DIFF
--- a/do_babi_run.py
+++ b/do_babi_run.py
@@ -73,7 +73,7 @@ def main(tasks_dir, output_dir, excluding=[], including_only=None, run_sequentia
     specs = [x for x in specs if x.task_name[5:] not in excluding]
     if including_only is not None:
         specs = [x for x in specs if x.task_name[5:] in including_only]
-    from pprint import pprint; pprint(specs); return
+    from pprint import pprint; pprint(specs);
     run_harness.run(tasks_dir, output_dir, base_params, specs, stop_on_error=stop_on_error, skip_complete=just_setup)
 
 parser = argparse.ArgumentParser(description="Train all bAbI tasks.")


### PR DESCRIPTION
The return statement is stopping run_harness from being executed. So removing that.